### PR TITLE
Prevent public IP from accessing the system

### DIFF
--- a/server/admin.php
+++ b/server/admin.php
@@ -1,11 +1,7 @@
 <?php
   require_once("functions.php");
 
-  if (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_PW'] != GlobalConfig::$admin_pass) {
-    header('WWW-Authenticate: Basic realm="Eink admin panel"');
-    header('HTTP/1.0 401 Unauthorized');
-    die('Need user/pass auth to get here!');
-  }
+  checkUserAuth(true);
 
   // Render a widget
   if (isset($_GET["action"]) && $_GET["action"] == "renderthumb") {

--- a/server/auth.php
+++ b/server/auth.php
@@ -1,0 +1,16 @@
+<?php
+  require_once("functions.php");
+
+  function checkUserAuth($adminMode) {
+    if (GlobalConfig::$private_ip_only && filter_var($_SERVER["REMOTE_ADDR"], FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE)) {
+       header('HTTP/1.0 401 Unauthorized');
+       die('Only local client can connect this server!');
+    }
+    if ($adminMode && (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_PW'] != GlobalConfig::$admin_pass)) {
+      header('WWW-Authenticate: Basic realm="Eink admin panel"');
+      header('HTTP/1.0 401 Unauthorized');
+      die('Need user/pass auth to get here!');
+    }
+    return true;
+  }
+?>

--- a/server/config.php.sample
+++ b/server/config.php.sample
@@ -8,6 +8,9 @@ class GlobalConfig {
 	// Add your openweathermap key here
 	public static $weather_api_key = "";
 
+        // If set to true, access is only allowed to private IP address (not via public Internet)
+        public static $private_ip_only = false;
+
 };
 
 ?>

--- a/server/editor.php
+++ b/server/editor.php
@@ -1,11 +1,7 @@
 <?php
   require_once("functions.php");
 
-  if (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_PW'] != GlobalConfig::$admin_pass	) {
-    header('WWW-Authenticate: Basic realm="Eink admin panel"');
-    header('HTTP/1.0 401 Unauthorized');
-    die('Need user/pass auth to get here!');
-  }
+  checkUserAuth(true);
 
   // Save screen!
   if (isset($_GET["action"]) && isset($_GET["id"]) && $_GET["action"] == "save") {

--- a/server/functions.php
+++ b/server/functions.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once("config.php");
+require_once("auth.php");
 require_once("provider.php");
 require_once("weather.php");
 require_once("currency.php");

--- a/server/index.php
+++ b/server/index.php
@@ -2,6 +2,9 @@
 
 require_once("functions.php");
 
+// Make sure it's private network only
+checkUserAuth(false);
+
 function mapColor($color, $numc) {
 	return intval($color / intval(256/$numc));
 }


### PR DESCRIPTION
This change simply checks if the server is connected via the local network and deny answering if not. This allows installing on my front-end public HTTP server without fearing for anyone to fetch the pictures for the frame.
