### PR TITLE
Allow setting the ESP8266 toolchain path, and serial port used

### DIFF
--- a/esp8266_firmware/Makefile
+++ b/esp8266_firmware/Makefile
@@ -1,7 +1,9 @@
 CC = xtensa-lx106-elf-gcc
-CFLAGS = -I. -mlongcalls -std=c99 -ffunction-sections -fdata-sections -Os -DICACHE_FLASH
-LDLIBS = -nostdlib -Wl,--start-group -lmain -lnet80211 -lwpa -llwip -lpp -lphy -Wl,--end-group -lgcc 
-LDFLAGS = -Teagle.app.v6.ld -Wl,--gc-sections -flto  -Wl,-Map,fw.map
+ESPSDK = /Volumes/ESPtoolchain/esp-open-sdk/sdk
+PORT = /dev/cu.usbserial-FTG4YM5W
+CFLAGS = -I. -I$(ESPSDK)/include -mlongcalls -std=c99 -ffunction-sections -fdata-sections -Os -DICACHE_FLASH
+LDLIBS = -nostdlib -L$(ESPSDK)/lib -Wl,--start-group -lmain -lnet80211 -lwpa -llwip -lpp -lphy -Wl,--end-group -lgcc 
+LDFLAGS = -T$(ESPSDK)/ld/eagle.app.v6.ld -Wl,--gc-sections -flto  -Wl,-Map,fw.map
 
 firmware-0x00000.bin: firmware
 	esptool.py elf2image $^
@@ -13,7 +15,7 @@ firmware: main.o uart.o httpd.o spi.o
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 flash: firmware-0x00000.bin
-	esptool.py write_flash 0 firmware-0x00000.bin 0x40000 firmware-0x40000.bin
+	esptool.py --port $(PORT) write_flash 0 firmware-0x00000.bin 0x40000 firmware-0x40000.bin
 
 clean:
 	rm -f firmware main.o uart.o firmware-0x00000.bin firmware-0x400000.bin


### PR DESCRIPTION
This makes life a lot easier when the ESP's SDK is not in your local path (and it should not be).
